### PR TITLE
#27,#28 - create_date 에 따라 게시글 정렬해서 가져오기, 게시글 좋아요 처리

### DIFF
--- a/src/main/java/com/example/travel/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/travel/config/WebSecurityConfig.java
@@ -21,7 +21,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class WebSecurityConfig {
 
     private static final String[] PUBLIC_URLS = { //이 URL은 권한 검사안함. 아래 내용은 임시임.
-            "/signup", "/login", "/", "/board/**"
+            "/signup", "/login", "/"
     };
 
     private final JwtTokenProvider jwtTokenProvider;

--- a/src/main/java/com/example/travel/controller/BoardController.java
+++ b/src/main/java/com/example/travel/controller/BoardController.java
@@ -2,15 +2,16 @@ package com.example.travel.controller;
 
 import com.example.travel.dto.BoardRequestDto;
 import com.example.travel.dto.BoardResponseDto;
+import com.example.travel.dto.MemberLoginRequest;
+import com.example.travel.entity.Member;
 import com.example.travel.repository.BoardRepository;
 import com.example.travel.repository.MemberRepository;
 import com.example.travel.service.BoardService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import com.example.travel.response.Response;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
+import org.springframework.lang.Nullable;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -74,7 +75,26 @@ public class BoardController {
      */
     @PostMapping("/board/{id}")
     @ApiOperation(value = "게시글 좋아요", notes = "사용자가 게시글 좋아요를 누릅니다.")
-    public String thumbsUp(@PathVariable Long id) {
-        return boardService.thumbsUp(id);
+    public String thumbsUp(@PathVariable Long id, Authentication authentication) {
+        MemberLoginRequest memberLoginRequest = (MemberLoginRequest) authentication.getPrincipal();
+        String strMemberId = memberLoginRequest.getId();
+        return boardService.thumbsUp(id, strMemberId);
+    }
+
+    /**
+     * 게시글 최신 순으로 가져오기
+     * ?order = -createdDate : 내림차순 desc created_date
+     *
+     * 게시글 오래된 순으로 가져오기
+     * ?order = createdDate : 오름차순 asc create_date
+     */
+    @GetMapping("/boards")
+    @ApiOperation(value = "게시글 정렬", notes = "default 는 최신 순으로 게시글을 가져옵니다. order = createdDate 인 경우 오래된 순으로 가져옵니다.")
+    public List<BoardResponseDto> findByCreatedDateAsc(@RequestParam (required = false, defaultValue = "-createdDate") @Nullable String order,
+                                                       @RequestParam(required = false, defaultValue = "1") int page){
+        if(order.equals("-createdDate") || order.equals("")){
+            return boardService.findByCreatedDateDesc(page-1);
+        }
+        return boardService.findByCreatedDateAsc(page-1);
     }
 }

--- a/src/main/java/com/example/travel/entity/Board.java
+++ b/src/main/java/com/example/travel/entity/Board.java
@@ -76,18 +76,4 @@ public class Board {
     public void increaseHit() {
         this.hit++;
     }
-
-    /**
-     * 좋아요 수 증가
-     */
-    public void increaseThumb() {
-        this.thumb += 1;
-    }
-
-    /**
-     * 좋아요 수 차감
-     */
-    public void decreaseThumb() {
-        this.thumb -= 1;
-    }
 }


### PR DESCRIPTION
requestParam 의 order 값에 따라서 최신 순 or 오래된 순으로 게시글을 가져올 수 있다. 한 페이지에 10개의 게시글을 sorting 해줌. 회원과 게시글을 기준으로 db 에서 select 한 후 해당 게시글에 해당 회원이 좋아요를 누른 적이 있는지 확인하여 없는 경우 좋아요 +1, 이미 누른 후 라면 -1 함.